### PR TITLE
Dazfuller/2 create access class for azure data factory from interactive login

### DIFF
--- a/src/CarbonIntensityTime.Core/CarbonIntensityTime.Core.csproj
+++ b/src/CarbonIntensityTime.Core/CarbonIntensityTime.Core.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/src/CarbonIntensityTime.Core/Configuration/AppSettings.cs
+++ b/src/CarbonIntensityTime.Core/Configuration/AppSettings.cs
@@ -1,0 +1,6 @@
+﻿namespace CarbonIntensityTime.Core.Configuration;
+
+public class AppSettings
+{
+    public string? ApiKey { get; set; }
+}

--- a/src/CarbonIntensityTime.Core/Configuration/CodesSettings.cs
+++ b/src/CarbonIntensityTime.Core/Configuration/CodesSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace CarbonIntensityTime.Configuration;
+﻿namespace CarbonIntensityTime.Core.Configuration;
 
 public class CodesSettings
 {

--- a/src/CarbonIntensityTime.Core/Configuration/FactorySettings.cs
+++ b/src/CarbonIntensityTime.Core/Configuration/FactorySettings.cs
@@ -1,0 +1,34 @@
+﻿namespace CarbonIntensityTime.Core.Configuration;
+
+public class FactorySettings
+{
+    /// <summary>
+    /// Gets, sets the name of the Azure Data Factory instance
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets, sets the subscription id which the Azure Data Factory instance has been deployed to
+    /// </summary>
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets, sets the resource group which the Azure Data Factory instance has been deployed to
+    /// </summary>
+    public string ResourceGroup { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets, sets the tenant id for the tenant the Azure Data Factory instance has been deployed to
+    /// </summary>
+    public string TenantId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets, sets the client id. If this is null or empty then the default Azure credential will be used instead
+    /// </summary>
+    public string? ClientId { get; set; }
+    
+    /// <summary>
+    /// Gets, sets the client secret. If this is null or empty then the default Azure credential will be used instead
+    /// </summary>
+    public string? ClientSecret { get; set; }
+}

--- a/src/CarbonIntensityTime.DataFactory/CarbonIntensityTime.DataFactory.csproj
+++ b/src/CarbonIntensityTime.DataFactory/CarbonIntensityTime.DataFactory.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Azure.Identity" Version="1.9.0" />
+      <PackageReference Include="Microsoft.Azure.Management.DataFactory" Version="9.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\CarbonIntensityTime.Core\CarbonIntensityTime.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/CarbonIntensityTime.DataFactory/FactoryClient.cs
+++ b/src/CarbonIntensityTime.DataFactory/FactoryClient.cs
@@ -1,0 +1,84 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using CarbonIntensityTime.Core.Configuration;
+using Microsoft.Azure.Management.DataFactory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Rest;
+
+namespace CarbonIntensityTime.DataFactory;
+
+/// <summary>
+/// Methods for interacting with Azure Data Factory
+/// </summary>
+public class FactoryClient : IFactoryClient
+{
+    private readonly FactorySettings _factorySettings;
+    private readonly ILogger<FactoryClient> _logger;
+
+    private DataFactoryManagementClient? _client = null;
+    
+    /// <summary>
+    /// Creates a new instance of the <see cref="FactoryClient"/> class
+    /// </summary>
+    /// <param name="factorySettings">Options for defining which Factory instance to connect to and how</param>
+    /// <param name="logger">Logger instance</param>
+    public FactoryClient(IOptions<FactorySettings> factorySettings, ILogger<FactoryClient> logger)
+    {
+        _factorySettings = factorySettings.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// List pipelines in the Azure Data Factory instance
+    /// </summary>
+    public async Task<IList<string>> ListPipelines()
+    {
+        var client = await GetClient();
+
+        _logger.LogDebug("Retrieving pipelines");
+        var pipelines = await client.Pipelines.ListByFactoryAsync(_factorySettings.ResourceGroup, _factorySettings.Name);
+
+        return pipelines.Select(p => p.Name).ToList();
+    }
+
+    /// <summary>
+    /// Retrieves an Azure Data Factory client for working with Azure ADF
+    /// </summary>
+    /// <returns>A Data Factory Management client instance</returns>
+    private async Task<DataFactoryManagementClient> GetClient()
+    {
+        if (_client is not null)
+        {
+            _logger.LogDebug("Using existing client");
+            return _client;
+        }
+        
+        TokenCredential credential;
+        if (!string.IsNullOrEmpty(_factorySettings.ClientId) && !string.IsNullOrEmpty(_factorySettings.ClientSecret))
+        {
+            _logger.LogDebug("Connecting to Data Factory using client secret credentials");
+            credential = new ClientSecretCredential(_factorySettings.TenantId, _factorySettings.ClientId,
+                _factorySettings.ClientSecret);
+        }
+        else
+        {
+            _logger.LogDebug("Connecting to Data Factory using default credentials");
+            credential = new DefaultAzureCredential();
+        }
+
+        _logger.LogDebug("Requesting management access token");
+        var requestContext = new TokenRequestContext(new[] {"https://management.azure.com/.default"});
+        var cancellationToken = new CancellationToken();
+        var token = await credential.GetTokenAsync(requestContext, cancellationToken);
+
+        _logger.LogDebug("Creating Data Factory management client");
+        var adfCredentials = new TokenCredentials(token.Token);
+        _client = new DataFactoryManagementClient(adfCredentials)
+        {
+            SubscriptionId = _factorySettings.SubscriptionId
+        };
+
+        return _client;
+    }
+}

--- a/src/CarbonIntensityTime.DataFactory/IFactoryClient.cs
+++ b/src/CarbonIntensityTime.DataFactory/IFactoryClient.cs
@@ -1,0 +1,12 @@
+﻿namespace CarbonIntensityTime.DataFactory;
+
+/// <summary>
+/// Methods for interacting with Azure Data Factory
+/// </summary>
+public interface IFactoryClient
+{
+    /// <summary>
+    /// List pipelines in the Azure Data Factory instance
+    /// </summary>
+    Task<IList<string>> ListPipelines();
+}

--- a/src/CarbonIntensityTime.sln
+++ b/src/CarbonIntensityTime.sln
@@ -9,6 +9,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CarbonIntensityTimeCmdLine"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CarbonIntensityTypes", "CarbonIntensityTypes\CarbonIntensityTypes.csproj", "{9E79CC06-CEBB-4C8C-B693-DBD1208B928E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CarbonIntensityTime.DataFactory", "CarbonIntensityTime.DataFactory\CarbonIntensityTime.DataFactory.csproj", "{29AFE152-E204-43EC-B46A-104C63CCEDFC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CarbonIntensityTime.Core", "CarbonIntensityTime.Core\CarbonIntensityTime.Core.csproj", "{B1059012-9C88-4369-AACD-CC8AAC64D03E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +31,14 @@ Global
 		{9E79CC06-CEBB-4C8C-B693-DBD1208B928E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9E79CC06-CEBB-4C8C-B693-DBD1208B928E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9E79CC06-CEBB-4C8C-B693-DBD1208B928E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29AFE152-E204-43EC-B46A-104C63CCEDFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29AFE152-E204-43EC-B46A-104C63CCEDFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29AFE152-E204-43EC-B46A-104C63CCEDFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29AFE152-E204-43EC-B46A-104C63CCEDFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1059012-9C88-4369-AACD-CC8AAC64D03E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1059012-9C88-4369-AACD-CC8AAC64D03E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1059012-9C88-4369-AACD-CC8AAC64D03E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1059012-9C88-4369-AACD-CC8AAC64D03E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CarbonIntensityTime.sln.DotSettings
+++ b/src/CarbonIntensityTime.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Entsoe/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/CarbonIntensityTime/CarbonIntensityTime.csproj
+++ b/src/CarbonIntensityTime/CarbonIntensityTime.csproj
@@ -8,10 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CarbonIntensityTime.Core\CarbonIntensityTime.Core.csproj" />
     <ProjectReference Include="..\CarbonIntensityTypes\CarbonIntensityTypes.csproj" />
   </ItemGroup>
 

--- a/src/CarbonIntensityTime/CodesLoader.cs
+++ b/src/CarbonIntensityTime/CodesLoader.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json;
-using CarbonIntensityTime.Configuration;
+using CarbonIntensityTime.Core.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/src/CarbonIntensityTime/Configuration/AppSettings.cs
+++ b/src/CarbonIntensityTime/Configuration/AppSettings.cs
@@ -1,7 +1,0 @@
-﻿namespace CarbonIntensityTime.Configuration
-{
-   public class AppSettings
-   {
-      public string? ApiKey { get; set; }
-   }
-}

--- a/src/CarbonIntensityTime/EuropeanLoadHelper.cs
+++ b/src/CarbonIntensityTime/EuropeanLoadHelper.cs
@@ -23,7 +23,7 @@
 */
 
 using CarbonIntensityTypes;
-using CarbonIntensityTime.Configuration;
+using CarbonIntensityTime.Core.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 

--- a/src/CarbonIntensityTimeCmdLine/CarbonIntensityTimeCmdLine.csproj
+++ b/src/CarbonIntensityTimeCmdLine/CarbonIntensityTimeCmdLine.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CarbonIntensityTime.DataFactory\CarbonIntensityTime.DataFactory.csproj" />
     <ProjectReference Include="..\CarbonIntensityTime\CarbonIntensityTime.csproj" />
     <ProjectReference Include="..\CarbonIntensityTypes\CarbonIntensityTypes.csproj" />
   </ItemGroup>

--- a/src/CarbonIntensityTimeCmdLine/CarbonService.cs
+++ b/src/CarbonIntensityTimeCmdLine/CarbonService.cs
@@ -1,5 +1,4 @@
-﻿using CarbonIntensityTime;
-using CarbonIntensityTime.Configuration;
+﻿using CarbonIntensityTime.Core.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace CarbonIntensityTimeCmdLine

--- a/src/CarbonIntensityTimeCmdLine/Program.cs
+++ b/src/CarbonIntensityTimeCmdLine/Program.cs
@@ -1,5 +1,6 @@
 ﻿using CarbonIntensityTime;
-using CarbonIntensityTime.Configuration;
+using CarbonIntensityTime.Core.Configuration;
+using CarbonIntensityTime.DataFactory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -31,16 +32,24 @@ var serviceProvider = new ServiceCollection()
     })
     .Configure<AppSettings>(configuration.GetSection("AppSettings"))
     .Configure<CodesSettings>(configuration.GetSection("Codes"))
+    .Configure<FactorySettings>(configuration.GetSection("DataFactory"))
     .AddScoped<ICodesLoader, CodesLoader>()
     .AddScoped<IEntsoeHttpDriver, EntsoeHttpDriver>()
     .AddScoped<IEuropeanLoadHelper, EuropeanLoadHelper>()
+    .AddScoped<IFactoryClient, FactoryClient>()
     .BuildServiceProvider();
 
 var euro = serviceProvider.GetService<IEuropeanLoadHelper>();
 var ukCode = euro.GetEntsoeId("CTA|National Grid");
 
-
-
 var installedCapacity = await euro.GetInstalledCapacityByCountry(ukCode);
+
+var adfClient = serviceProvider.GetService<IFactoryClient>();
+var pipelines = await adfClient.ListPipelines();
+foreach (var pipeline in pipelines)
+{
+    Console.WriteLine(pipeline);
+}
+
 Console.WriteLine("PRESS ANY KEY TO END ....");
 Console.Read();

--- a/src/CarbonIntensityTimeCmdLine/appsettings.json
+++ b/src/CarbonIntensityTimeCmdLine/appsettings.json
@@ -2,5 +2,13 @@
   "Codes": {
     "Entsoe": "entsoe.json",
     "Fuels": "fuels.json"
+  },
+  "DataFactory": {
+    "Name": "<ADF instance name>",
+    "SubscriptionId": "<Subscription id for ADF instance>",
+    "ResourceGroup": "<Resource group name for ADF instance>",
+    "TenantId": "<Tenant id for ADF instance>",
+    "ClientId": null,
+    "ClientSecret": null
   }
 }

--- a/src/CarbonIntensityTypes/Generation Capacity Per Unit/CountryPsrCapacity.cs
+++ b/src/CarbonIntensityTypes/Generation Capacity Per Unit/CountryPsrCapacity.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CarbonIntensityTypes
+﻿namespace CarbonIntensityTypes
 {
    public class CountryPsrCapacity
    {


### PR DESCRIPTION
Add component for connecting to Azure Data Factory using either service principal or default credentials. Also moves some components to a "core" project to avoid dependency issues.

If either the client id or secret are null or empty strings then the default credentials are used